### PR TITLE
Resolved #2

### DIFF
--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -20,21 +20,21 @@ contract Contract {
         seller = _seller;
     }
     struct adds{
-        string memory city;
-        string memory country;
-        string memory addline;
+        string  city;
+        string  country;
+        string  addline;
     }
     struct Property {
-       string memory name;
-       string memory email;
-       string memory phoneno;
+       string  name;
+       string  email;
+       string  phoneno;
        adds adds;
-       string memory proptype;
-       string memory amenities;
+       string  proptype;
+       string  amenities;
        uint256 sqfoot;
        uint256 bedno;
-       string memory img;
-       string memory descp;
+       string  img;
+       string  descp;
     }
 
     


### PR DESCRIPTION
#2 => The memory keyword cannot be used inside a struct declaration as these structs are meant to define the layout of data in storage or as part of the contract's state. Unlike function parameters or local variables, which are temporary and stored in memory, struct members are stored in the contract's storage or are part of the contract's state. Therefore, specifying memory for struct members would be contradictory, as structs are intended to define data storage layout, not temporary data.