### PR TITLE
Resolved #8

### DIFF
--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -6,7 +6,7 @@ interface IERC721 {
         address _from,
         address _to,
         uint256 _id
-    );
+    )external;
 }
 contract Contract {
     address public nftaddress;


### PR DESCRIPTION
#8 =>  For importing of the interface into other contracts it must be mentioned as external .