### PR TITLE
Simplified cancelSale function Resolved #7

### DIFF
--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -142,8 +142,13 @@ contract Contract {
     function cancelSale(uint256 _nftID) public {
         require(msg.sender == seller || msg.sender == buyer[_nftID],"Only seller or buyer can use this method");
         require(isListed[_nftID],"Property is not listed for sale");
-        IERC721(nftaddress).transferFrom(address(this), seller, _nftID);
+        try IERC721(nftaddress).transferFrom(address(this), seller, _nftID) {
         isListed[_nftID] = false;
+        return true;
+        } catch {
+        return false;
+        }
+
     }
 
     function retprice (uint256 _nftID) public view returns (uint256) {

--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -142,12 +142,10 @@ contract Contract {
     function cancelSale(uint256 _nftID) public {
         require(msg.sender == seller || msg.sender == buyer[_nftID],"Only seller or buyer can use this method");
         require(isListed[_nftID],"Property is not listed for sale");
-        try IERC721(nftaddress).transferFrom(address(this), seller, _nftID) {
-        isListed[_nftID] = false;
-        return true;
-        } catch {
-        return false;
-        }
+       bool transferSuccess = IERC721(nftaddress).transferFrom(address(this), seller, _nftID);
+    require(transferSuccess, "NFT transfer failed");
+    
+    isListed[_nftID] = false;
 
     }
 

--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -140,8 +140,10 @@ contract Contract {
         return isListed[_nftID];
     }
     function cancelSale(uint256 _nftID) public {
-        require(1==1);
-       (bool success, ) = payable(buyer[_nftID]).call{value: address(this).balance}("");
+        require(msg.sender == seller || msg.sender == buyer[_nftID],"Only seller or buyer can use this method");
+        require(isListed[_nftID],"Property is not listed for sale");
+        IERC721(nftaddress).transferFrom(address(this), seller, _nftID);
+        isListed[_nftID] = false;
     }
 
     function retprice (uint256 _nftID) public view returns (uint256) {


### PR DESCRIPTION
#7 => Firstly, the right to cancel the Sale is given only to the seller and buyer .Then the NFT for the property is checked (whether or not it is available for the sale) . If the seller wants to cancel the sale of that property then the NFT of that particular property is deprecated from the list and then finally removed the unnecessary line of code.