### PR TITLE
String handling using memory keyword

### DIFF
--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -51,11 +51,12 @@ contract Contract {
     
     function list1(
         uint256 _nftID, 
-       string  _amenities,
+    // memory used to pass strings that won't be stored after function ends
+       string  memory _amenities,
        uint256 _sqfoot,
        uint256 _bedno,
-       string  _img,
-       string _descp,
+       string  memory _img,
+       string memory _descp,
        uint256 _purchasePrice,
        uint256 _tokenID)public {
         IERC721(nftaddress).transferFrom(seller, address(this), _tokenID);


### PR DESCRIPTION
Resolved #1 
Improved the reliability of the list1 function in Contract.sol by making sure that string data is handled correctly. It involved using the memory keyword.
<img width="569" alt="Screenshot 2024-03-15 at 4 50 38 PM" src="https://github.com/iiitl/realty/assets/143395668/71b2f674-fb3d-45e0-829c-41f381fb9be9">

