### PR TITLE
Memory Usage Optimization within Solidity Structs #2

### DIFF
--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -51,11 +51,12 @@ contract Contract {
     
     function list1(
         uint256 _nftID, 
-       string  _amenities,
+    // memory used to pass strings that won't be stored after function ends
+       string  memory _amenities,
        uint256 _sqfoot,
        uint256 _bedno,
-       string  _img,
-       string _descp,
+       string  memory _img,
+       string memory _descp,
        uint256 _purchasePrice,
        uint256 _tokenID)public {
         IERC721(nftaddress).transferFrom(seller, address(this), _tokenID);

--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -20,21 +20,21 @@ contract Contract {
         seller = _seller;
     }
     struct adds{
-        string memory city;
-        string memory country;
-        string memory addline;
+        string city;
+        string country;
+        string addline;
     }
     struct Property {
-       string memory name;
-       string memory email;
-       string memory phoneno;
+       string name;
+       string email;
+       string phoneno;
        adds adds;
-       string memory proptype;
-       string memory amenities;
+       string proptype;
+       string amenities;
        uint256 sqfoot;
        uint256 bedno;
-       string memory img;
-       string memory descp;
+       string img;
+       string descp;
     }
 
     


### PR DESCRIPTION
Resolved #2 
Removed the memory keyword in string declarations within structs. This is done to ensure that struct members persist.
<img width="276" alt="Screenshot 2024-03-15 at 5 05 59 PM" src="https://github.com/iiitl/realty/assets/143395668/1b5d5ed2-3401-493e-af15-3bc080b6e3cb">
