### PR TITLE
Correct Variable Declaration in Function Parameters #1

### DIFF
--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -20,21 +20,21 @@ contract Contract {
         seller = _seller;
     }
     struct adds{
-        string memory city;
-        string memory country;
-        string memory addline;
+        string city;
+        string country;
+        string addline;
     }
     struct Property {
-       string memory name;
-       string memory email;
-       string memory phoneno;
+       string name;
+       string  email;
+       string phoneno;
        adds adds;
-       string memory proptype;
-       string memory amenities;
+       string  proptype;
+       string  amenities;
        uint256 sqfoot;
        uint256 bedno;
-       string memory img;
-       string memory descp;
+       string  img;
+       string  descp;
     }
 
     

--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -51,11 +51,11 @@ contract Contract {
     
     function list1(
         uint256 _nftID, 
-       string  _amenities,
-       uint256 _sqfoot,
+       string  memory _amenities,
+       uint256  _sqfoot,
        uint256 _bedno,
-       string  _img,
-       string _descp,
+       string memory _img,
+       string memory _descp,
        uint256 _purchasePrice,
        uint256 _tokenID)public {
         IERC721(nftaddress).transferFrom(seller, address(this), _tokenID);


### PR DESCRIPTION
Solved issue #1 use the memory keyword as string cannot be directly stored inside the temporary memory of blockchain(unlike uint), it needs to be specified with the memory keyword. Using memory is generally cheaper in terms of gas costs.
![Screenshot (437)](https://github.com/iiitl/realty/assets/131036775/65cbf7e5-840c-4ba3-af44-5e893417a689)
