### PR TITLE
Correct Variable Declaration in Function Parameters #1

### DIFF
--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -51,11 +51,11 @@ contract Contract {
     
     function list1(
         uint256 _nftID, 
-       string  _amenities,
+       string  memory _amenities,
        uint256 _sqfoot,
        uint256 _bedno,
-       string  _img,
-       string _descp,
+       string  memory _img,
+       string memory _descp,
        uint256 _purchasePrice,
        uint256 _tokenID)public {
         IERC721(nftaddress).transferFrom(seller, address(this), _tokenID);


### PR DESCRIPTION
Fixes: #1 

use the memory keyword as a string cannot be directly stored inside the temporary memory of the blockchain(unlike uint), it needs to be specified with the memory keyword. Using memory is generally cheaper in terms of gas costs.

![image](https://github.com/iiitl/realty/assets/65962770/8a2603d6-eca4-4fef-a4c2-7bbafd2ea088)
